### PR TITLE
Moved home urls under debian/ from bitbucket to github

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,8 +9,8 @@ Build-Depends: debhelper (>= 9),
                node-less,
                translate-toolkit
 Standards-Version: 3.9.8
-Homepage: https://bitbucket.org/ubuntu-mate/software-boutique
-Vcs-Browser: https://bitbucket.org/ubuntu-mate/software-boutique/src
+Homepage: https://github.com/ubuntu-mate/software-boutique
+Vcs-Browser: https://github.com/ubuntu-mate/software-boutique
 
 Package: software-boutique
 Architecture: all

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,7 +1,7 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: software-boutique
 Upstream-Contact: Martin Wimpress <code@flexion.org>
-Source: https://bitbucket.org/ubuntu-mate/software-boutique
+Source: https://github.com/ubuntu-mate/software-boutique
 
 Files: debian/*
        .tx/config


### PR DESCRIPTION
If these few edits are helpful then good.  Guessed that the removal of /src so Homepage and Vcs-Browser are the same would be right.  No remaining refs to bitbucket.

That just leaves two launchpad references in 

 **debian/control**: (Maintainer: ..  )
 and  
**software-boutique**:    (url = )




